### PR TITLE
feat: Add alarm and protection binary sensors for Pylontech

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,39 @@ pylontech_rs485:
   # the component will stop talking to the inverter.
   # Default: 60s
   update_timeout: 60s
+
+  # --- Optional Alarm and Protection Binary Sensors ---
+  # Uncomment and link to ESPHome binary_sensor entities to report alarm and protection statuses.
+  # These are typically used for simulation/testing purposes with the pylontech-emulator-example.yaml.
+  #
+  # Alarm Status 1
+  # total_voltage_high_alarm: alarm_total_voltage_high
+  # total_voltage_low_alarm: alarm_total_voltage_low
+  # cell_voltage_high_alarm: alarm_cell_voltage_high
+  # cell_voltage_low_alarm: alarm_cell_voltage_low
+  # cell_temp_high_alarm: alarm_cell_temp_high
+  # cell_temp_low_alarm: alarm_cell_temp_low
+  # mosfet_temp_high_alarm: alarm_mosfet_temp_high
+  # cell_imbalance_alarm: alarm_cell_imbalance
+  #
+  # Alarm Status 2
+  # cell_temp_imbalance_alarm: alarm_cell_temp_imbalance
+  # charge_overcurrent_alarm: alarm_charge_over_current
+  # discharge_overcurrent_alarm: alarm_discharge_over_current
+  #
+  # Protection Status 1
+  # module_overvoltage_protection: protection_module_overvoltage
+  # module_undervoltage_protection: protection_module_undervoltage
+  # cell_overvoltage_protection: protection_cell_overvoltage
+  # cell_undervoltage_protection: protection_cell_undervoltage
+  # cell_overtemp_protection: protection_cell_over_temperature
+  # cell_undertemp_protection: protection_cell_under_temperature
+  # mosfet_overtemp_protection: protection_mosfet_over_temperature
+  #
+  # Protection Status 2
+  # charge_overcurrent_protection: protection_charge_over_current
+  # discharge_overcurrent_protection: protection_discharge_over_current
+  # system_fault_protection: protection_system_fault
 ```
 
 ### Parameter Descriptions:
@@ -118,6 +151,29 @@ pylontech_rs485:
     *   `min_bms_temperature` (Optional): The ID of an ESPHome `sensor` entity that provides the minimum BMS temperature in Celsius.
 
 *   `update_timeout` (Optional, default: `60s`): The duration after which, if no new data is received from the linked sensors, the component will stop sending data to the inverter.
+
+*   **Optional Alarm and Protection Binary Sensors:**
+    *   `total_voltage_high_alarm` (Optional): The ID of an ESPHome `binary_sensor` entity that indicates if the total battery voltage is too high.
+    *   `total_voltage_low_alarm` (Optional): The ID of an ESPHome `binary_sensor` entity that indicates if the total battery voltage is too low.
+    *   `cell_voltage_high_alarm` (Optional): The ID of an ESPHome `binary_sensor` entity that indicates if any cell voltage is too high.
+    *   `cell_voltage_low_alarm` (Optional): The ID of an ESPHome `binary_sensor` entity that indicates if any cell voltage is too low.
+    *   `cell_temp_high_alarm` (Optional): The ID of an ESPHome `binary_sensor` entity that indicates if any cell temperature is too high.
+    *   `cell_temp_low_alarm` (Optional): The ID of an ESPHome `binary_sensor` entity that indicates if any cell temperature is too low.
+    *   `mosfet_temp_high_alarm` (Optional): The ID of an ESPHome `binary_sensor` entity that indicates if the MOSFET temperature is too high.
+    *   `cell_temp_imbalance_alarm` (Optional): The ID of an ESPHome `binary_sensor` entity that indicates if there is a cell temperature imbalance.
+    *   `cell_imbalance_alarm` (Optional): The ID of an ESPHome `binary_sensor` entity that indicates if there is a cell voltage imbalance.
+    *   `charge_overcurrent_alarm` (Optional): The ID of an ESPHome `binary_sensor` entity that indicates if there is a charge overcurrent alarm.
+    *   `discharge_overcurrent_alarm` (Optional): The ID of an ESPHome `binary_sensor` entity that indicates if there is a discharge overcurrent alarm.
+    *   `module_overvoltage_protection` (Optional): The ID of an ESPHome `binary_sensor` entity that indicates if module overvoltage protection is active.
+    *   `module_undervoltage_protection` (Optional): The ID of an ESPHome `binary_sensor` entity that indicates if module undervoltage protection is active.
+    *   `cell_overvoltage_protection` (Optional): The ID of an ESPHome `binary_sensor` entity that indicates if cell overvoltage protection is active.
+    *   `cell_undervoltage_protection` (Optional): The ID of an ESPHome `binary_sensor` entity that indicates if cell undervoltage protection is active.
+    *   `cell_overtemp_protection` (Optional): The ID of an ESPHome `binary_sensor` entity that indicates if cell overtemperature protection is active.
+    *   `cell_undertemp_protection` (Optional): The ID of an ESPHome `binary_sensor` entity that indicates if cell undertemperature protection is active.
+    *   `mosfet_overtemp_protection` (Optional): The ID of an ESPHome `binary_sensor` entity that indicates if MOSFET overtemperature protection is active.
+    *   `charge_overcurrent_protection` (Optional): The ID of an ESPHome `binary_sensor` entity that indicates if charge overcurrent protection is active.
+    *   `discharge_overcurrent_protection` (Optional): The ID of an ESPHome `binary_sensor` entity that indicates if discharge overcurrent protection is active.
+    *   `system_fault_protection` (Optional): The ID of an ESPHome `binary_sensor` entity that indicates if system fault protection is active.
 
 ## Providing Battery Data (The Core Concept)
 
@@ -166,8 +222,7 @@ graph TD
 
 ## Future Development
 
-*   Add dynamic alarm generation to the `62H` handler based on live sensor data.
-*   Add support for other inverter "dialects" (e.g., Growatt).
+*   Add support for other inverters if needed.
 
 ## Contributing
 

--- a/components/pylontech_rs485/pylontech_rs485.h
+++ b/components/pylontech_rs485/pylontech_rs485.h
@@ -3,6 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
 #include "esphome/components/sensor/sensor.h"
+#include "esphome/components/binary_sensor/binary_sensor.h"
 
 namespace esphome {
 namespace pylontech_rs485 {
@@ -35,6 +36,29 @@ class PylontechRS485 : public Component, public uart::UARTDevice {
   void set_bms_temperature_sensor(sensor::Sensor *sensor) { this->bms_temperature_sensor_ = sensor; }
   void set_max_bms_temperature_sensor(sensor::Sensor *sensor) { this->max_bms_temperature_sensor_ = sensor; }
   void set_min_bms_temperature_sensor(sensor::Sensor *sensor) { this->min_bms_temperature_sensor_ = sensor; }
+
+  // --- Setters for Binary Sensors ---
+  void set_total_voltage_high_alarm(binary_sensor::BinarySensor *sensor) { this->total_voltage_high_alarm_ = sensor; }
+  void set_total_voltage_low_alarm(binary_sensor::BinarySensor *sensor) { this->total_voltage_low_alarm_ = sensor; }
+  void set_cell_voltage_high_alarm(binary_sensor::BinarySensor *sensor) { this->cell_voltage_high_alarm_ = sensor; }
+  void set_cell_voltage_low_alarm(binary_sensor::BinarySensor *sensor) { this->cell_voltage_low_alarm_ = sensor; }
+  void set_cell_temp_high_alarm(binary_sensor::BinarySensor *sensor) { this->cell_temp_high_alarm_ = sensor; }
+  void set_cell_temp_low_alarm(binary_sensor::BinarySensor *sensor) { this->cell_temp_low_alarm_ = sensor; }
+  void set_mosfet_temp_high_alarm(binary_sensor::BinarySensor *sensor) { this->mosfet_temp_high_alarm_ = sensor; }
+  void set_cell_imbalance_alarm(binary_sensor::BinarySensor *sensor) { this->cell_imbalance_alarm_ = sensor; }
+  void set_cell_temp_imbalance_alarm(binary_sensor::BinarySensor *sensor) { this->cell_temp_imbalance_alarm_ = sensor; }
+  void set_charge_overcurrent_alarm(binary_sensor::BinarySensor *sensor) { this->charge_overcurrent_alarm_ = sensor; }
+  void set_discharge_overcurrent_alarm(binary_sensor::BinarySensor *sensor) { this->discharge_overcurrent_alarm_ = sensor; }
+  void set_module_overvoltage_protection(binary_sensor::BinarySensor *sensor) { this->module_overvoltage_protection_ = sensor; }
+  void set_module_undervoltage_protection(binary_sensor::BinarySensor *sensor) { this->module_undervoltage_protection_ = sensor; }
+  void set_cell_overvoltage_protection(binary_sensor::BinarySensor *sensor) { this->cell_overvoltage_protection_ = sensor; }
+  void set_cell_undervoltage_protection(binary_sensor::BinarySensor *sensor) { this->cell_undervoltage_protection_ = sensor; }
+  void set_cell_overtemp_protection(binary_sensor::BinarySensor *sensor) { this->cell_overtemp_protection_ = sensor; }
+  void set_cell_undertemp_protection(binary_sensor::BinarySensor *sensor) { this->cell_undertemp_protection_ = sensor; }
+  void set_mosfet_overtemp_protection(binary_sensor::BinarySensor *sensor) { this->mosfet_overtemp_protection_ = sensor; }
+  void set_charge_overcurrent_protection(binary_sensor::BinarySensor *sensor) { this->charge_overcurrent_protection_ = sensor; }
+  void set_discharge_overcurrent_protection(binary_sensor::BinarySensor *sensor) { this->discharge_overcurrent_protection_ = sensor; }
+  void set_system_fault_protection(binary_sensor::BinarySensor *sensor) { this->system_fault_protection_ = sensor; }
   
   // Setters for dynamic limits
   void set_max_voltage_sensor(sensor::Sensor *sensor) { this->max_voltage_sensor_ = sensor; }
@@ -87,6 +111,30 @@ class PylontechRS485 : public Component, public uart::UARTDevice {
   sensor::Sensor *max_bms_temperature_sensor_{nullptr};
   sensor::Sensor *min_bms_temperature_sensor_{nullptr};
 
+  // --- Pointers for Binary Sensors ---
+  binary_sensor::BinarySensor *total_voltage_high_alarm_{nullptr};
+  binary_sensor::BinarySensor *total_voltage_low_alarm_{nullptr};
+  binary_sensor::BinarySensor *cell_voltage_high_alarm_{nullptr};
+  binary_sensor::BinarySensor *cell_voltage_low_alarm_{nullptr};
+  binary_sensor::BinarySensor *cell_temp_high_alarm_{nullptr};
+  binary_sensor::BinarySensor *cell_temp_low_alarm_{nullptr};
+  binary_sensor::BinarySensor *mosfet_temp_high_alarm_{nullptr};
+  binary_sensor::BinarySensor *cell_imbalance_alarm_{nullptr};
+  binary_sensor::BinarySensor *cell_temp_imbalance_alarm_{nullptr};
+  binary_sensor::BinarySensor *charge_overcurrent_alarm_{nullptr};
+  binary_sensor::BinarySensor *discharge_overcurrent_alarm_{nullptr};
+  binary_sensor::BinarySensor *module_overvoltage_protection_{nullptr};
+  binary_sensor::BinarySensor *module_undervoltage_protection_{nullptr};
+  binary_sensor::BinarySensor *cell_overvoltage_protection_{nullptr};
+  binary_sensor::BinarySensor *cell_undervoltage_protection_{nullptr};
+  binary_sensor::BinarySensor *cell_overtemp_protection_{nullptr};
+  binary_sensor::BinarySensor *cell_undertemp_protection_{nullptr};
+  binary_sensor::BinarySensor *mosfet_overtemp_protection_{nullptr};
+  binary_sensor::BinarySensor *charge_overcurrent_protection_{nullptr};
+  binary_sensor::BinarySensor *discharge_overcurrent_protection_{nullptr};
+  binary_sensor::BinarySensor *system_fault_protection_{nullptr};
+
+  // --- Pointers for dynamic limit sensors ---
   sensor::Sensor *max_voltage_sensor_{nullptr};
   sensor::Sensor *min_voltage_sensor_{nullptr};
   sensor::Sensor *max_charge_current_sensor_{nullptr};

--- a/pylontech-emulator-example.yaml
+++ b/pylontech-emulator-example.yaml
@@ -54,6 +54,7 @@ uart:
 
 # --- Define global variables to hold the state of our sliders ---
 globals:
+  # --- sensors ---
   - id: g_soc
     type: float
     restore_value: yes
@@ -86,6 +87,94 @@ globals:
     type: float
     restore_value: yes
     initial_value: '100.0'
+
+  # --- Alarms ---
+  - id: g_alarm_total_voltage_high
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+  - id: g_alarm_total_voltage_low
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+  - id: g_alarm_cell_voltage_high
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+  - id: g_alarm_cell_voltage_low
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+  - id: g_alarm_cell_temp_high
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+  - id: g_alarm_cell_temp_low
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+  - id: g_alarm_mosfet_temp_high
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+  - id: g_alarm_cell_temp_imbalance
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+  - id: g_alarm_cell_imbalance
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+  - id: g_alarm_charge_over_current
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+  - id: g_alarm_discharge_over_current
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+
+  # --- Protections ---
+  - id: g_protection_module_overvoltage
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+  - id: g_protection_module_undervoltage
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+  - id: g_protection_cell_overvoltage
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+  - id: g_protection_cell_undervoltage
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+  - id: g_protection_cell_over_temperature
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+  - id: g_protection_cell_under_temperature
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+  - id: g_protection_mosfet_over_temperature
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+  - id: g_protection_charge_over_current
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+  - id: g_protection_discharge_over_current
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+  - id: g_protection_system_fault
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
 
 # --- Number entities (sliders) that Home Assistant will see ---
 number:
@@ -200,6 +289,198 @@ number:
       - globals.set:
           id: g_max_discharge_i
           value: !lambda 'return x;'
+
+switch:
+  # --- Alarm Switches ---
+  - platform: template
+    name: "Simulated Alarm: Total Voltage High"
+    id: switch_alarm_total_voltage_high
+    lambda: return id(g_alarm_total_voltage_high);
+    turn_on_action:
+      - globals.set: { id: g_alarm_total_voltage_high, value: 'true' }
+    turn_off_action:
+      - globals.set: { id: g_alarm_total_voltage_high, value: 'false' }
+
+  - platform: template
+    name: "Simulated Alarm: Total Voltage Low"
+    id: switch_alarm_total_voltage_low
+    lambda: return id(g_alarm_total_voltage_low);
+    turn_on_action:
+      - globals.set: { id: g_alarm_total_voltage_low, value: 'true' }
+    turn_off_action:
+      - globals.set: { id: g_alarm_total_voltage_low, value: 'false' }
+
+  - platform: template
+    name: "Simulated Alarm: Cell Voltage High"
+    id: switch_alarm_cell_voltage_high
+    lambda: return id(g_alarm_cell_voltage_high);
+    turn_on_action:
+      - globals.set: { id: g_alarm_cell_voltage_high, value: 'true' }
+    turn_off_action:
+      - globals.set: { id: g_alarm_cell_voltage_high, value: 'false' }
+
+  - platform: template
+    name: "Simulated Alarm: Cell Voltage Low"
+    id: switch_alarm_cell_voltage_low
+    lambda: return id(g_alarm_cell_voltage_low);
+    turn_on_action:
+      - globals.set: { id: g_alarm_cell_voltage_low, value: 'true' }
+    turn_off_action:
+      - globals.set: { id: g_alarm_cell_voltage_low, value: 'false' }
+
+  - platform: template
+    name: "Simulated Alarm: Cell Temperature High"
+    id: switch_alarm_cell_temp_high
+    lambda: return id(g_alarm_cell_temp_high);
+    turn_on_action:
+      - globals.set: { id: g_alarm_cell_temp_high, value: 'true' }
+    turn_off_action:
+      - globals.set: { id: g_alarm_cell_temp_high, value: 'false' }
+
+  - platform: template
+    name: "Simulated Alarm: Cell Temperature Low"
+    id: switch_alarm_cell_temp_low
+    lambda: return id(g_alarm_cell_temp_low);
+    turn_on_action:
+      - globals.set: { id: g_alarm_cell_temp_low, value: 'true' }
+    turn_off_action:
+      - globals.set: { id: g_alarm_cell_temp_low, value: 'false' }
+
+  - platform: template
+    name: "Simulated Alarm: MOSFET Temperature High"
+    id: switch_alarm_mosfet_temp_high
+    lambda: return id(g_alarm_mosfet_temp_high);
+    turn_on_action:
+      - globals.set: { id: g_alarm_mosfet_temp_high, value: 'true' }
+    turn_off_action:
+      - globals.set: { id: g_alarm_mosfet_temp_high, value: 'false' }
+
+  - platform: template
+    name: "Simulated Alarm: Cell Temperature Imbalance"
+    id: switch_alarm_cell_temp_imbalance
+    lambda: return id(g_alarm_cell_temp_imbalance);
+    turn_on_action:
+      - globals.set: { id: g_alarm_cell_temp_imbalance, value: 'true' }
+    turn_off_action:
+      - globals.set: { id: g_alarm_cell_temp_imbalance, value: 'false' }
+
+  - platform: template
+    name: "Simulated Alarm: Cell Imbalance"
+    id: switch_alarm_cell_imbalance
+    lambda: return id(g_alarm_cell_imbalance);
+    turn_on_action:
+      - globals.set: { id: g_alarm_cell_imbalance, value: 'true' }
+    turn_off_action:
+      - globals.set: { id: g_alarm_cell_imbalance, value: 'false' }
+
+  - platform: template
+    name: "Simulated Alarm: Charge Over Current"
+    id: switch_alarm_charge_over_current
+    lambda: return id(g_alarm_charge_over_current);
+    turn_on_action:
+      - globals.set: { id: g_alarm_charge_over_current, value: 'true' }
+    turn_off_action:
+      - globals.set: { id: g_alarm_charge_over_current, value: 'false' }
+
+  - platform: template
+    name: "Simulated Alarm: Discharge Over Current"
+    id: switch_alarm_discharge_over_current
+    lambda: return id(g_alarm_discharge_over_current);
+    turn_on_action:
+      - globals.set: { id: g_alarm_discharge_over_current, value: 'true' }
+    turn_off_action:
+      - globals.set: { id: g_alarm_discharge_over_current, value: 'false' }
+
+  # --- Protection Switches ---
+  - platform: template
+    name: "Simulated Protection: Module Overvoltage"
+    id: switch_protection_module_overvoltage
+    lambda: return id(g_protection_module_overvoltage);
+    turn_on_action:
+      - globals.set: { id: g_protection_module_overvoltage, value: 'true' }
+    turn_off_action:
+      - globals.set: { id: g_protection_module_overvoltage, value: 'false' }
+
+  - platform: template
+    name: "Simulated Protection: Module Undervoltage"
+    id: switch_protection_module_undervoltage
+    lambda: return id(g_protection_module_undervoltage);
+    turn_on_action:
+      - globals.set: { id: g_protection_module_undervoltage, value: 'true' }
+    turn_off_action:
+      - globals.set: { id: g_protection_module_undervoltage, value: 'false' }
+
+  - platform: template
+    name: "Simulated Protection: Cell Overvoltage"
+    id: switch_protection_cell_overvoltage
+    lambda: return id(g_protection_cell_overvoltage);
+    turn_on_action:
+      - globals.set: { id: g_protection_cell_overvoltage, value: 'true' }
+    turn_off_action:
+      - globals.set: { id: g_protection_cell_overvoltage, value: 'false' }
+
+  - platform: template
+    name: "Simulated Protection: Cell Undervoltage"
+    id: switch_protection_cell_undervoltage
+    lambda: return id(g_protection_cell_undervoltage);
+    turn_on_action:
+      - globals.set: { id: g_protection_cell_undervoltage, value: 'true' }
+    turn_off_action:
+      - globals.set: { id: g_protection_cell_undervoltage, value: 'false' }
+
+  - platform: template
+    name: "Simulated Protection: Cell Overtemperature"
+    id: switch_protection_cell_over_temperature
+    lambda: return id(g_protection_cell_over_temperature);
+    turn_on_action:
+      - globals.set: { id: g_protection_cell_over_temperature, value: 'true' }
+    turn_off_action:
+      - globals.set: { id: g_protection_cell_over_temperature, value: 'false' }
+
+  - platform: template
+    name: "Simulated Protection: Cell Undertemperature"
+    id: switch_protection_cell_under_temperature
+    lambda: return id(g_protection_cell_under_temperature);
+    turn_on_action:
+      - globals.set: { id: g_protection_cell_under_temperature, value: 'true' }
+    turn_off_action:
+      - globals.set: { id: g_protection_cell_under_temperature, value: 'false' }
+
+  - platform: template
+    name: "Simulated Protection: MOSFET Overtemperature"
+    id: switch_protection_mosfet_over_temperature
+    lambda: return id(g_protection_mosfet_over_temperature);
+    turn_on_action:
+      - globals.set: { id: g_protection_mosfet_over_temperature, value: 'true' }
+    turn_off_action:
+      - globals.set: { id: g_protection_mosfet_over_temperature, value: 'false' }
+
+  - platform: template
+    name: "Simulated Protection: Charge Overcurrent"
+    id: switch_protection_charge_over_current
+    lambda: return id(g_protection_charge_over_current);
+    turn_on_action:
+      - globals.set: { id: g_protection_charge_over_current, value: 'true' }
+    turn_off_action:
+      - globals.set: { id: g_protection_charge_over_current, value: 'false' }
+
+  - platform: template
+    name: "Simulated Protection: Discharge Overcurrent"
+    id: switch_protection_discharge_over_current
+    lambda: return id(g_protection_discharge_over_current);
+    turn_on_action:
+      - globals.set: { id: g_protection_discharge_over_current, value: 'true' }
+    turn_off_action:
+      - globals.set: { id: g_protection_discharge_over_current, value: 'false' }
+
+  - platform: template
+    name: "Simulated Protection: System Fault"
+    id: switch_protection_system_fault
+    lambda: return id(g_protection_system_fault);
+    turn_on_action:
+      - globals.set: { id: g_protection_system_fault, value: 'true' }
+    turn_off_action:
+      - globals.set: { id: g_protection_system_fault, value: 'false' }
 
 # ===================================================================
 # 3. Template Sensors to provide the live data
@@ -322,7 +603,141 @@ sensor:
     unit_of_measurement: "°C"
 
 # ===================================================================
-# 4. Configure the Pylontech RS485 Component
+# 4. Alarms and Warnings binary sensors
+# ===================================================================
+
+binary_sensor:
+
+  # --- Binary sensors for alarms and warnings ---
+  - platform: template
+    id: alarm_total_voltage_high
+    name: "Alarm Total Voltage High"
+    lambda: return id(g_alarm_total_voltage_high);
+    device_class: problem
+
+  - platform: template
+    id: alarm_total_voltage_low
+    name: "Alarm Total Voltage Low"
+    lambda: return id(g_alarm_total_voltage_low);
+    device_class: problem
+
+  - platform: template
+    id: alarm_cell_voltage_high
+    name: "Alarm Cell Voltage High"
+    lambda: return id(g_alarm_cell_voltage_high);
+    device_class: problem
+
+  - platform: template
+    id: alarm_cell_voltage_low
+    name: "Alarm Cell Voltage Low"
+    lambda: return id(g_alarm_cell_voltage_low);
+    device_class: problem
+
+  - platform: template
+    id: alarm_cell_temp_high
+    name: "Alarm Cell Temperature High"
+    lambda: return id(g_alarm_cell_temp_high);
+    device_class: problem
+
+  - platform: template
+    id: alarm_cell_temp_low
+    name: "Alarm Cell Temperature Low"
+    lambda: return id(g_alarm_cell_temp_low);
+    device_class: problem
+
+  - platform: template
+    id: alarm_mosfet_temp_high
+    name: "Alarm MOSFET Temperature High"
+    lambda: return id(g_alarm_mosfet_temp_high);
+    device_class: problem
+
+  - platform: template
+    id: alarm_cell_temp_imbalance
+    name: "Alarm Cell Temperature Imbalance"
+    lambda: return id(g_alarm_cell_temp_imbalance);
+    device_class: problem
+  
+  - platform: template
+    id: alarm_cell_imbalance
+    name: "Alarm Cell Imbalance"
+    lambda: return id(g_alarm_cell_imbalance);
+    device_class: problem
+
+  - platform: template
+    id: alarm_charge_over_current
+    name: "Alarm Charge Over Current"
+    lambda: return id(g_alarm_charge_over_current);
+    device_class: problem
+
+  - platform: template
+    id: alarm_discharge_over_current
+    name: "Alarm Discharge Over Current"
+    lambda: return id(g_alarm_discharge_over_current);
+    device_class: problem
+
+  # --- Binary sensors for protection module ---
+  - platform: template
+    id: protection_module_overvoltage
+    name: "Protection Module Overvoltage"
+    lambda: return id(g_protection_module_overvoltage);
+    device_class: problem
+
+  - platform: template
+    id: protection_module_undervoltage
+    name: "Protection Module Undervoltage"
+    lambda: return id(g_protection_module_undervoltage);
+    device_class: problem
+
+  - platform: template
+    id: protection_cell_overvoltage
+    name: "Protection Cell Overvoltage"
+    lambda: return id(g_protection_cell_overvoltage);
+    device_class: problem
+
+  - platform: template
+    id: protection_cell_undervoltage
+    name: "Protection Cell Undervoltage"
+    lambda: return id(g_protection_cell_undervoltage);
+    device_class: problem
+
+  - platform: template
+    id: protection_cell_over_temperature
+    name: "Protection Cell Overtemperature"
+    lambda: return id(g_protection_cell_over_temperature);
+    device_class: problem
+
+  - platform: template
+    id: protection_cell_under_temperature
+    name: "Protection Cell Undertemperature"
+    lambda: return id(g_protection_cell_under_temperature);
+    device_class: problem
+
+  - platform: template
+    id: protection_mosfet_over_temperature
+    name: "Protection MOSFET Overtemperature"
+    lambda: return id(g_protection_mosfet_over_temperature);
+    device_class: problem
+
+  - platform: template
+    id: protection_charge_over_current
+    name: "Protection Charge Overcurrent"
+    lambda: return id(g_protection_charge_over_current);
+    device_class: problem
+
+  - platform: template
+    id: protection_discharge_over_current
+    name: "Protection Discharge Overcurrent"
+    lambda: return id(g_protection_discharge_over_current);
+    device_class: problem
+
+  - platform: template
+    id: protection_system_fault
+    name: "Protection System Fault"
+    lambda: return id(g_protection_system_fault);
+    device_class: problem
+
+# ===================================================================
+# 5. Configure the Pylontech RS485 Component
 # ===================================================================
 pylontech_rs485:
   uart_id: uart_bus
@@ -356,6 +771,37 @@ pylontech_rs485:
   bms_temperature: live_bms_temp
   max_bms_temperature: live_max_bms_temp
   min_bms_temperature: live_min_bms_temp
+
+  # Alarms and warnings
+
+  # Alarm Status 1
+  total_voltage_high_alarm: alarm_total_voltage_high
+  total_voltage_low_alarm: alarm_total_voltage_low
+  cell_voltage_high_alarm: alarm_cell_voltage_high
+  cell_voltage_low_alarm: alarm_cell_voltage_low
+  cell_temp_high_alarm: alarm_cell_temp_high
+  cell_temp_low_alarm: alarm_cell_temp_low
+  mosfet_temp_high_alarm: alarm_mosfet_temp_high
+  cell_imbalance_alarm: alarm_cell_imbalance
+
+  # Alarm Status 2
+  cell_temp_imbalance_alarm: alarm_cell_temp_imbalance
+  charge_overcurrent_alarm: alarm_charge_over_current
+  discharge_overcurrent_alarm: alarm_discharge_over_current
+
+  # Protection Status 1
+  module_overvoltage_protection: protection_module_overvoltage
+  module_undervoltage_protection: protection_module_undervoltage
+  cell_overvoltage_protection: protection_cell_overvoltage
+  cell_undervoltage_protection: protection_cell_undervoltage
+  cell_overtemp_protection: protection_cell_over_temperature
+  cell_undertemp_protection: protection_cell_under_temperature
+  mosfet_overtemp_protection: protection_mosfet_over_temperature
+
+  # Protection Status 2
+  charge_overcurrent_protection: protection_charge_over_current
+  discharge_overcurrent_protection: protection_discharge_over_current
+  system_fault_protection: protection_system_fault
 
   # Dynamic battery limits (for command 63)
   max_voltage: live_max_v


### PR DESCRIPTION
Introduce new binary sensors for monitoring various alarm and protection states of Pylontech batteries, including over/under voltage and temperature conditions. Update documentation to detail the optional sensors for simulation and testing purposes.